### PR TITLE
Beta support concurrent nodepool CRUD Operations

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -378,9 +378,25 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-
+<% if version == "ga" -%>	
 	mutexKV.Lock(nodePoolInfo.lockKey())
 	defer mutexKV.Unlock(nodePoolInfo.lockKey())
+<% else -%>
+	clusterHash, err := getClusterHash(nodePoolInfo, userAgent, config)
+	if err != nil {
+			return err
+	}
+
+	// Acquire read-lock on cluster.
+	clusterLockKey := nodePoolInfo.lockKey()
+	mutexKV.RLock(clusterLockKey)
+	defer mutexKV.RUnlock(clusterLockKey)
+
+	// Acquire write-lock on nodepool.
+	npLockKey := nodePoolLockKey(clusterHash, nodePool.Name)
+	mutexKV.Lock(npLockKey)
+	defer mutexKV.Unlock(npLockKey)
+<% end -%>
 
 	req := &container.CreateNodePoolRequest{
 		NodePool: nodePool,
@@ -464,11 +480,13 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
+<% if version == "ga" %>
 	//Check cluster is in running state
 	_, err = containerClusterAwaitRestingState(config, nodePoolInfo.project, nodePoolInfo.location, nodePoolInfo.cluster, userAgent, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
+<% end -%>
 
 	state, err := containerNodePoolAwaitRestingState(config, d.Id(), nodePoolInfo.project, userAgent, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
@@ -554,11 +572,13 @@ func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 	name := getNodePoolName(d.Id())
 
+<% if version == "ga" -%>
 	//Check cluster is in running state
 	_, err = containerClusterAwaitRestingState(config, nodePoolInfo.project, nodePoolInfo.location, nodePoolInfo.cluster, userAgent, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
+<% end -%>
 
 	_, err = containerNodePoolAwaitRestingState(config, nodePoolInfo.fullyQualifiedName(name), nodePoolInfo.project, userAgent, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
@@ -598,6 +618,7 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 
 	name := getNodePoolName(d.Id())
 
+<% if version == "ga" -%>
 	//Check cluster is in running state
 	_, err = containerClusterAwaitRestingState(config, nodePoolInfo.project, nodePoolInfo.location, nodePoolInfo.cluster, userAgent, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
@@ -607,6 +628,7 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 		}
 		return err
 	}
+<% end -%>
 
 	_, err = containerNodePoolAwaitRestingState(config, nodePoolInfo.fullyQualifiedName(name), nodePoolInfo.project, userAgent, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
@@ -620,9 +642,25 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
+<% if version == "ga" -%>
 	mutexKV.Lock(nodePoolInfo.lockKey())
 	defer mutexKV.Unlock(nodePoolInfo.lockKey())
+<% else -%>
+	clusterHash, err := getClusterHash(nodePoolInfo, userAgent, config)
+	if err != nil {
+			return err
+	}
 
+	// Acquire read-lock on cluster.
+	clusterLockKey := nodePoolInfo.lockKey()
+	mutexKV.RLock(clusterLockKey)
+	defer mutexKV.RUnlock(clusterLockKey)
+
+	// Acquire write-lock on nodepool.
+	npLockKey := nodePoolLockKey(clusterHash, name)
+	mutexKV.Lock(npLockKey)
+	defer mutexKV.Unlock(npLockKey)
+<% end -%>
 
 	timeout := d.Timeout(schema.TimeoutDelete)
 	startTime := time.Now()
@@ -980,12 +1018,27 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 	config := meta.(*Config)
 	name := d.Get(prefix + "name").(string)
 
-	lockKey := nodePoolInfo.lockKey()
-
 	userAgent, err := generateUserAgentString(d, config.userAgent)
 	if err != nil {
 		return err
 	}
+	
+<% if version == "ga" -%>
+	lockKey := nodePoolInfo.lockKey()
+<% else -%>
+	clusterHash, err := getClusterHash(nodePoolInfo, userAgent, config)
+	if err != nil {
+			return err
+	}
+
+	// Acquire read-lock on cluster.
+	clusterLockKey := nodePoolInfo.lockKey()
+	mutexKV.RLock(clusterLockKey)
+	defer mutexKV.RUnlock(clusterLockKey)
+
+	// Nodepool write-lock will be acquired when update function is called.
+	npLockKey := nodePoolLockKey(clusterHash, name)
+<% end -%>
 
 	if d.HasChange(prefix + "autoscaling") {
 		update := &container.ClusterUpdate{
@@ -1029,11 +1082,16 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 				timeout)
 		}
 
+<% if version == "ga" -%>
 		// Call update serially.
 		if err := lockedCall(lockKey, updateF); err != nil {
 			return err
 		}
-
+<% else -%>
+		if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+				return err
+		}
+<% end -%>
 		log.Printf("[INFO] Updated autoscaling in Node Pool %s", d.Id())
 	}
 
@@ -1063,10 +1121,16 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 					timeout)
 			}
 
+<% if version == "ga" -%>
 			// Call update serially.
 			if err := lockedCall(lockKey, updateF); err != nil {
 				return err
 			}
+<% else -%>
+			if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+					return err
+			}
+<% end -%>
 
 			log.Printf("[INFO] Updated image type in Node Pool %s", d.Id())
 		}
@@ -1099,10 +1163,16 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 					timeout)
 			}
 
+<% if version == "ga" -%>
 			// Call update serially.
 			if err := lockedCall(lockKey, updateF); err != nil {
 				return err
 			}
+<% else -%>
+			if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+					return err
+			}
+<% end -%>
 
 			log.Printf("[INFO] Updated workload_metadata_config for node pool %s", name)
 		}
@@ -1135,9 +1205,8 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 					timeout)
 			}
 
-			// Call update serially.
-			if err := lockedCall(lockKey, updateF); err != nil {
-				return err
+			if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+					return err
 			}
 
 			log.Printf("[INFO] Updated kubelet_config for node pool %s", name)
@@ -1169,9 +1238,8 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 					timeout)
 			}
 
-			// Call update serially.
-			if err := lockedCall(lockKey, updateF); err != nil {
-				return err
+			if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+					return err
 			}
 
 			log.Printf("[INFO] Updated linux_node_config for node pool %s", name)
@@ -1203,10 +1271,16 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 				timeout)
 		}
 
+<% if version == "ga" -%>
 		// Call update serially.
 		if err := lockedCall(lockKey, updateF); err != nil {
 			return err
 		}
+<% else -%>
+		if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+				return err
+		}
+<% end -%>
 
 		log.Printf("[INFO] GKE node pool %s size has been updated to %d", name, newSize)
 	}
@@ -1240,10 +1314,16 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 				nodePoolInfo.location, "updating GKE node pool management", userAgent, timeout)
 		}
 
+<% if version == "ga" -%>
 		// Call update serially.
 		if err := lockedCall(lockKey, updateF); err != nil {
 			return err
 		}
+<% else -%>
+		if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+				return err
+		}
+<% end -%>
 
 		log.Printf("[INFO] Updated management in Node Pool %s", name)
 	}
@@ -1270,10 +1350,16 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 				nodePoolInfo.location, "updating GKE node pool version", userAgent, timeout)
 		}
 
+<% if version == "ga" -%>
 		// Call update serially.
 		if err := lockedCall(lockKey, updateF); err != nil {
 			return err
 		}
+<% else -%>
+		if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+				return err
+		}
+<% end -%>
 
 		log.Printf("[INFO] Updated version in Node Pool %s", name)
 	}
@@ -1297,10 +1383,16 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			return containerOperationWait(config, op, nodePoolInfo.project, nodePoolInfo.location, "updating GKE node pool node locations", userAgent, timeout)
 		}
 
+<% if version == "ga" -%>
 		// Call update serially.
 		if err := lockedCall(lockKey, updateF); err != nil {
 			return err
 		}
+<% else -%>
+		if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+				return err
+		}
+<% end -%>
 
 		log.Printf("[INFO] Updated node locations in Node Pool %s", name)
 	}
@@ -1330,10 +1422,16 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			return containerOperationWait(config, op, nodePoolInfo.project, nodePoolInfo.location, "updating GKE node pool upgrade settings", userAgent, timeout)
 		}
 
+<% if version == "ga" -%>
 		// Call update serially.
 		if err := lockedCall(lockKey, updateF); err != nil {
 			return err
 		}
+<% else -%>
+		if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+				return err
+		}
+<% end -%>
 
 		log.Printf("[INFO] Updated upgrade settings in Node Pool %s", name)
 	}

--- a/mmv1/third_party/terraform/utils/mutexkv.go
+++ b/mmv1/third_party/terraform/utils/mutexkv.go
@@ -13,7 +13,7 @@ import (
 // their access to individual security groups based on SG ID.
 type MutexKV struct {
 	lock  sync.Mutex
-	store map[string]*sync.Mutex
+	store map[string]*sync.RWMutex
 }
 
 // Locks the mutex for the given key. Caller is responsible for calling Unlock
@@ -31,13 +31,28 @@ func (m *MutexKV) Unlock(key string) {
 	log.Printf("[DEBUG] Unlocked %q", key)
 }
 
+// Acquires a read-lock on the mutex for the given key. Caller is responsible for calling RUnlock
+// for the same key
+func (m *MutexKV) RLock(key string) {
+	log.Printf("[DEBUG] RLocking %q", key)
+	m.get(key).RLock()
+	log.Printf("[DEBUG] RLocked %q", key)
+}
+
+// Releases a read-lock on the mutex for the given key. Caller must have called RLock for the same key first
+func (m *MutexKV) RUnlock(key string) {
+	log.Printf("[DEBUG] RUnlocking %q", key)
+	m.get(key).RUnlock()
+	log.Printf("[DEBUG] RUnlocked %q", key)
+}
+
 // Returns a mutex for the given key, no guarantee of its lock status
-func (m *MutexKV) get(key string) *sync.Mutex {
+func (m *MutexKV) get(key string) *sync.RWMutex {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	mutex, ok := m.store[key]
 	if !ok {
-		mutex = &sync.Mutex{}
+		mutex = &sync.RWMutex{}
 		m.store[key] = mutex
 	}
 	return mutex
@@ -46,6 +61,6 @@ func (m *MutexKV) get(key string) *sync.Mutex {
 // Returns a properly initialized MutexKV
 func NewMutexKV() *MutexKV {
 	return &MutexKV{
-		store: make(map[string]*sync.Mutex),
+		store: make(map[string]*sync.RWMutex),
 	}
 }

--- a/mmv1/third_party/terraform/utils/utils.go
+++ b/mmv1/third_party/terraform/utils/utils.go
@@ -588,7 +588,7 @@ func nodePoolLockKey(clusterHash string, npName string) string {
 func retryWhileIncompatibleOperation(timeout time.Duration, lockKey string, f func() error) error {
 	return resource.Retry(timeout, func() *resource.RetryError {
 		if err := lockedCall(lockKey, f); err != nil {
-			if retry, _ := isFailedPreconditionError(err); retry {
+			if isFailedPreconditionError(err) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/mmv1/third_party/terraform/utils/utils.go
+++ b/mmv1/third_party/terraform/utils/utils.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"google.golang.org/api/googleapi"
@@ -558,4 +559,40 @@ func checkGoogleIamPolicy(value string) error {
 		return fmt.Errorf("found an empty description field (should be omitted) in google_iam_policy data source: %s", value)
 	}
 	return nil
+}
+
+// Gets cluster hash from fully-qualified cluster name.
+func getClusterHash(npInfo *NodePoolInformation, userAgent string, config *Config) (string, error) {
+	getClusterCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Get(npInfo.parent())
+	if config.UserProjectOverride {
+		getClusterCall.Header().Add("X-Goog-User-Project", npInfo.project)
+	}
+	res, err := getClusterCall.Do()
+	if err != nil {
+		return "", err
+	}
+	return res.Id, nil
+}
+
+// Gets nodepool-level lock key. Guarantees uniqueness by using
+// the cluster hash (globally unique) and nodepool name (unique
+// within a cluster).
+func nodePoolLockKey(clusterHash string, npName string) string {
+	return fmt.Sprintf("clusters/%s/nodePools/%s", clusterHash, npName)
+}
+
+// Retries an operation while the canonical error code is FAILED_PRECONDTION
+// which indicates there is an incompatible operation already running on the
+// cluster. This error can be safely retried until the incompatible operation
+// completes, and the newly requested operation can begin.
+func retryWhileIncompatibleOperation(timeout time.Duration, lockKey string, f func() error) error {
+	return resource.Retry(timeout, func() *resource.RetryError {
+		if err := lockedCall(lockKey, f); err != nil {
+			if retry, _ := isFailedPreconditionError(err); retry {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
The purpose of these changes is to implement support in the beta provider for concurrent nodepool CRUD operations on a single cluster. The GA provider should be unchanged.

The changes to the beta provider include:
- Updating the global mutex store to use `sync.RWMutex` instead of `sync.Mutex` and adding the necessary methods to the `MutexKV` struct to support acquiring shared/read locks.
- Removing the polling for cluster "ready" status, since with support for concurrent operations on the same cluster we no longer need to wait for the cluster to have no operations running on it before proceeding.
- For NP CRUD operations, instead of acquiring an exclusive/write lock on the cluster, we acquire a read/shared lock on the cluster and an exclusive/write lock on the nodepool. This ensures cluster-wide operations (e.g. UpdateCluster) still will block NP level operations, but NP level operations on different NPs won't block eachother. These NP-level mutexes use cluster hash + nodepool name to guarantee lock key uniqueness.
- Add retry logic to NP CRUD operations to retry while it receives an "incompatible operation" error (which has the `FAILED_PRECONDITION` canonical code), to safely retry concurrent operations blocked by a lock conflict with another operation.